### PR TITLE
Feature/split by tools

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "php": "^7.4",
     "ext-ctype": "*",
     "ext-dom": "*",
+    "ext-hash": "*",
     "ext-intl": "*",
     "ext-json": "*",
     "ext-mbstring": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce746da8ddef4180cf3679487ba026d1",
+    "content-hash": "8ddabcf9c4cee7769ff70b4f6fd8bb07",
     "packages": [
         {
             "name": "composer/semver",
@@ -2081,6 +2081,7 @@
         "php": "^7.4",
         "ext-ctype": "*",
         "ext-dom": "*",
+        "ext-hash": "*",
         "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/src/Repository/Tool.php
+++ b/src/Repository/Tool.php
@@ -72,6 +72,11 @@ class Tool implements IteratorAggregate
         return isset($this->versions[$version]);
     }
 
+    public function isEmpty(): bool
+    {
+        return empty($this->versions);
+    }
+
     /**
      * Iterate over all versions.
      *


### PR DESCRIPTION
This PR implements the dumping of each tool into separate include files.

Doing so should reduce the amount to download from the repository significantly, as only the changed portions have to be fetched instead of the whole repository all the time.

It also somehow relates to #3 as this way we can at least see which files are changed.